### PR TITLE
Split `appId` into "task-id" & "destination path"

### DIFF
--- a/src/osx/ContentSync.m
+++ b/src/osx/ContentSync.m
@@ -569,7 +569,6 @@ didCompleteWithError:(NSError*) error {
 - (void) zipArchiveProgressEvent:(NSInteger) loaded total:(NSInteger) total {
     ContentSyncTask* sTask = [self findSyncDataByPath];
     if (sTask) {
-        NSLog(@"zipArchiveProgressEvent: %@", sTask.archivePath);
         //NSLog(@"Extracting %ld / %ld", (long)loaded, (long)total);
         double progress = ((double) loaded / (double) total);
         progress = (sTask.extractArchive ? ((0.5 + progress / 2) * 100) : progress * 100);

--- a/src/osx/ContentSync.m
+++ b/src/osx/ContentSync.m
@@ -222,8 +222,8 @@
         if (downloadURL == nil) {
             pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsInt:INVALID_URL_ERR];
 
-        } else if ([self findSyncDataByAppId:appId]) {
-            NSLog(@"Download task already started for %@", appId);
+        } else if ([self findSyncDataBySrc:src]) {
+            NSLog(@"Download task already started for %@", src);
             pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsInt:IN_PROGRESS_ERR];
 
         } else {
@@ -267,10 +267,10 @@
 }
 
 - (void) cancel:(CDVInvokedUrlCommand*) command __unused {
-    NSString* appId = [command argumentAtIndex:0 withDefault:nil];
-    NSLog(@"Cancelling download %@", appId);
-    if (appId) {
-        ContentSyncTask* sTask = [self findSyncDataByAppId:appId];
+    NSString* src = [command argumentAtIndex:0 withDefault:nil];
+    NSLog(@"Cancelling download %@", src);
+    if (src) {
+        ContentSyncTask* sTask = [self findSyncDataBySrc:src];
         if (sTask) {
             CDVPluginResult* pluginResult = nil;
             [[sTask downloadTask] cancel];
@@ -298,7 +298,7 @@
 - (ContentSyncTask*) findSyncDataByDownloadTask:(NSURLSessionDownloadTask*) downloadTask {
     @synchronized (self) {
         for (ContentSyncTask* sTask in syncTasks) {
-            if (sTask.downloadTask == downloadTask) {
+            if ([sTask.downloadTask isEqual:downloadTask]) {
                 return sTask;
             }
         }
@@ -317,10 +317,21 @@
     }
 }
 
-- (ContentSyncTask*) findSyncDataByAppId:(NSString*) appId {
+- (ContentSyncTask*) findSyncDataByArchivePath:(NSString*) archivePath {
     @synchronized (self) {
         for (ContentSyncTask* sTask in syncTasks) {
-            if ([sTask.appId isEqualToString:appId]) {
+            if ([sTask.archivePath isEqualToString:archivePath]) {
+                return sTask;
+            }
+        }
+        return nil;
+    }
+}
+
+- (ContentSyncTask*) findSyncDataBySrc:(NSString*) src {
+    @synchronized (self) {
+        for (ContentSyncTask* sTask in syncTasks) {
+            if ([[sTask.command argumentAtIndex:0] isEqualToString:src]) {
                 return sTask;
             }
         }
@@ -393,7 +404,10 @@ didFinishDownloadingToURL:(NSURL*) downloadURL {
     NSURL* storageDirectory = [ContentSync getStorageDirectory];
 
     NSURL* originalURL = [[downloadTask originalRequest] URL];
-    NSURL* sourceURL = [storageDirectory URLByAppendingPathComponent:[originalURL lastPathComponent]];
+    NSString* originalLastComponent = [originalURL lastPathComponent];
+    NSString* randomString = [[NSNumber numberWithInt:arc4random_uniform(100000)] stringValue];
+    NSURL* sourceURL = [storageDirectory URLByAppendingPathComponent:
+                        [NSString stringWithFormat:@"%@%@%@", @"tmp", randomString, originalLastComponent]];
     NSError* errorCopy;
 
     [fileManager removeItemAtURL:sourceURL error:NULL];
@@ -403,6 +417,8 @@ didFinishDownloadingToURL:(NSURL*) downloadURL {
         ContentSyncTask* sTask = [self findSyncDataByDownloadTask:downloadTask];
         if (sTask) {
             sTask.archivePath = [sourceURL path];
+            NSLog(@"Downloaded %@ and moved to %@ (%@)", originalURL, sTask.archivePath);
+            
             if (sTask.extractArchive && [self isZipArchive:[sourceURL path]]) {
                 // FIXME there is probably a better way to do this
                 NSURL* extractURL = [storageDirectory URLByAppendingPathComponent:[sTask appId]];
@@ -468,7 +484,7 @@ didCompleteWithError:(NSError*) error {
                 [self removeSyncTask:sTask];
             } else {
                 double progress = (double) task.countOfBytesReceived / (double) task.countOfBytesExpectedToReceive;
-                NSLog(@"Task: %@ completed successfully", sTask.archivePath);
+                NSLog(@"Task: %@ completed successfully (%@)", sTask.archivePath, sTask.extractArchive ? @"YES" : @"NO");
                 if (sTask.extractArchive) {
                     progress = ((progress / 2) * 100);
                     pluginResult = [self preparePluginResult:(NSInteger) progress status:Downloading];
@@ -526,18 +542,21 @@ didCompleteWithError:(NSError*) error {
 
         @try {
             NSError* error;
+            NSLog(@"unzipFileAtPath:%@ toDestination:%@", [sourceURL path], [destinationURL path]);
             if (![SSZipArchive unzipFileAtPath:[sourceURL path] toDestination:[destinationURL path] overwrite:YES password:nil error:&error delegate:weakSelf]) {
                 NSLog(@"%@ - %@", @"Error occurred during unzipping", [error localizedDescription]);
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsInt:UNZIP_ERR];
             } else {
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
                 // clean up zip archive
+                NSLog(@"clean up zip archive: %@", sourceURL);
                 [fileManager removeItemAtURL:sourceURL error:NULL];
 
             }
         }
         @catch (NSException* exception) {
             NSLog(@"%@ - %@", @"Error occurred during unzipping", [exception debugDescription]);
+            // remove task?
             pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsInt:UNZIP_ERR];
         }
         [pluginResult setKeepCallbackAsBool:YES];
@@ -549,12 +568,14 @@ didCompleteWithError:(NSError*) error {
 }
 
 - (void) zipArchiveWillUnzipArchiveAtPath:(NSString*) path zipInfo:(unz_global_info) zipInfo {
+    NSLog(@"set currentPath to: %@", path);
     self.currentPath = path;
 }
 
 - (void) zipArchiveProgressEvent:(NSInteger) loaded total:(NSInteger) total {
     ContentSyncTask* sTask = [self findSyncDataByPath];
     if (sTask) {
+        NSLog(@"zipArchiveProgressEvent: %@", sTask.archivePath);
         //NSLog(@"Extracting %ld / %ld", (long)loaded, (long)total);
         double progress = ((double) loaded / (double) total);
         progress = (sTask.extractArchive ? ((0.5 + progress / 2) * 100) : progress * 100);
@@ -565,8 +586,8 @@ didCompleteWithError:(NSError*) error {
 }
 
 - (void) zipArchiveDidUnzipArchiveAtPath:(NSString*) path zipInfo:(unz_global_info) zipInfo unzippedPath:(NSString*) unzippedPath {
-    NSLog(@"unzipped path %@", unzippedPath);
-    ContentSyncTask* sTask = [self findSyncDataByPath];
+    ContentSyncTask* sTask = [self findSyncDataByArchivePath:path];
+    NSLog(@"unzipped %@ to path %@", sTask.archivePath, unzippedPath);
     if (sTask) {
         BOOL copyCordovaAssets = [[[sTask command] argumentAtIndex:4 withDefault:@(NO)] boolValue];
         BOOL copyRootApp = [[[sTask command] argumentAtIndex:5 withDefault:@(NO)] boolValue];


### PR DESCRIPTION
As a dev I want to download multiple apps in the same destination folder. That makes sense with the "merge" strategy in order to share assets.

Problem: This is currently not possible because the "appId" is used for both..
- unique task id
- destination path

This PR:
- uses `src` as unique task id because src is always unique per app and content-package
- replaces `findSyncDataByPath` with `findSyncDataByArchivePath` where possible because "current download path" gets randomly overwritten in the current implementation and tasks are not cleaned up properly. As a consequence we see "ERROR 5", but that's wrong.

TODO:
- Remove NSLog in a dedicated commit

Follow-up:
- Will change iOS and Android code in dedicate PR.
